### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/mnemonic/path.go
+++ b/mnemonic/path.go
@@ -42,11 +42,11 @@ func pathToNodes(path string) ([]int, error) {
 	// Convert the remaining strings to integers
 	var result []int
 	for _, index := range indices {
-		intVal, err := strconv.Atoi(index)
+		uintVal, err := strconv.ParseUint(index, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid index in path: %s", index)
 		}
-		result = append(result, intVal)
+		result = append(result, int(uintVal))
 	}
 
 	return result, nil


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/bn254-keystore-go/security/code-scanning/2](https://github.com/Layr-Labs/bn254-keystore-go/security/code-scanning/2)

To fix the problem, we need to ensure that the integer values parsed from the string are within the bounds of `uint32` before performing the cast. This can be achieved by using `strconv.ParseUint` with a specified bit size of 32, which directly returns a `uint64` value. We can then safely cast this value to `uint32` after ensuring it is within the valid range.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
